### PR TITLE
feat(openclaw): 使用 user_data 注入初始化脚本并改用 ED25519 密钥免密登录

### DIFF
--- a/openclaw/main.tf
+++ b/openclaw/main.tf
@@ -65,6 +65,9 @@ resource "qiniu_compute_instance" "openclaw" {
   # root 用户密码
   password = var.root_password
 
+  # 初始化系统与配置 OpenClaw 用户
+  user_data = base64encode(module.openclaw_scripts.init_script)
+
   timeouts {
     create = "30m"
     update = "20m"

--- a/openclaw/openclaw_scripts/init.tf
+++ b/openclaw/openclaw_scripts/init.tf
@@ -9,7 +9,7 @@ resource "tls_private_key" "keypair" {
 output "init_script" {
   value = templatefile("${path.module}/templates/init.sh.tmpl", {
     openclaw_password   = var.openclaw_password
-    openclaw_public_key = tls_private_key.keypair.public_key_openssh
+    openclaw_public_key = chomp(tls_private_key.keypair.public_key_openssh)
   })
 }
 

--- a/openclaw/openclaw_scripts/init.tf
+++ b/openclaw/openclaw_scripts/init.tf
@@ -2,8 +2,19 @@ variable "openclaw_password" {
   type = string
 }
 
+resource "tls_private_key" "keypair" {
+  algorithm = "ED25519"
+}
+
 output "init_script" {
   value = templatefile("${path.module}/templates/init.sh.tmpl", {
-    openclaw_password = var.openclaw_password
+    openclaw_password   = var.openclaw_password
+    openclaw_public_key = tls_private_key.keypair.public_key_openssh
   })
+}
+
+output "openclaw_private_key" {
+  description = "ED25519 私钥（OpenSSH 格式），用于 SSH 登录 openclaw 用户"
+  sensitive   = true
+  value       = tls_private_key.keypair.private_key_openssh
 }

--- a/openclaw/openclaw_scripts/templates/init.sh.tmpl
+++ b/openclaw/openclaw_scripts/templates/init.sh.tmpl
@@ -28,7 +28,25 @@ fi
 printf '%s:%s\n' "$OPENCLAW_USER" "${ openclaw_password }" | chpasswd
 log "Password set for $OPENCLAW_USER"
 
-# 3. 开启 linger（幂等：已开启执行也无报错，加 || true 兜底）
+# 3. 注入 SSH 公钥（幂等：公钥已存在则跳过写入）
+OPENCLAW_HOME="$(getent passwd "$OPENCLAW_USER" | cut -d: -f6)"
+SSH_DIR="$OPENCLAW_HOME/.ssh"
+AUTH_KEYS="$SSH_DIR/authorized_keys"
+OPENCLAW_PUBKEY="${ openclaw_public_key }"
+
+install -d -m 700 -o "$OPENCLAW_USER" -g "$OPENCLAW_USER" "$SSH_DIR"
+touch "$AUTH_KEYS"
+chmod 600 "$AUTH_KEYS"
+chown "$OPENCLAW_USER":"$OPENCLAW_USER" "$AUTH_KEYS"
+
+if grep -qF "$OPENCLAW_PUBKEY" "$AUTH_KEYS" 2>/dev/null; then
+    log "SSH public key already present, skip."
+else
+    printf '%s\n' "$OPENCLAW_PUBKEY" >> "$AUTH_KEYS"
+    log "SSH public key injected for $OPENCLAW_USER"
+fi
+
+# 4. 开启 linger（幂等：已开启执行也无报错，加 || true 兜底）
 if ! loginctl show-user "$OPENCLAW_USER" | grep -q "Linger=yes"; then
     loginctl enable-linger "$OPENCLAW_USER"
     log "Enabled linger for $OPENCLAW_USER"
@@ -36,7 +54,7 @@ else
     log "Linger already enabled, skip."
 fi
 
-# 4. 标记初始化完成（幂等：存在则不重复 touch）
+# 5. 标记初始化完成（幂等：存在则不重复 touch）
 if [[ ! -f "$COMPLETE_FLAG" ]]; then
     touch "$COMPLETE_FLAG"
     log "Created init complete flag file."

--- a/openclaw/scripts.tf
+++ b/openclaw/scripts.tf
@@ -24,6 +24,8 @@ resource "terraform_data" "script_model_config" {
 
   provisioner "remote-exec" {
     inline = [
+      # user_data 异步执行，等待初始化脚本完成后再执行后续配置
+      "for i in $(seq 1 120); do [ -f /var/log/openclaw-init-complete ] && break; echo 'Waiting for OpenClaw initialization to complete...'; sleep 5; done; [ -f /var/log/openclaw-init-complete ] || { echo 'OpenClaw init not completed within 10 minutes'; exit 1; }",
       nonsensitive(self.triggers_replace.script_content),
     ]
   }

--- a/openclaw/scripts.tf
+++ b/openclaw/scripts.tf
@@ -6,53 +6,25 @@ module "openclaw_scripts" {
   channel_qq_token   = var.channel_qq_token
 }
 
-resource "terraform_data" "script_init" {
-  triggers_replace = {
-    instance_id  = qiniu_compute_instance.openclaw.id
-    ssh_host     = local.ssh_endpoint[0]
-    ssh_port     = local.ssh_endpoint[1]
-    ssh_password = var.root_password
-  }
-
-  connection {
-    type     = "ssh"
-    host     = local.ssh_endpoint[0]
-    user     = "root"
-    port     = local.ssh_endpoint[1]
-    password = var.root_password
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      nonsensitive(module.openclaw_scripts.init_script),
-    ]
-  }
-}
-
-
 resource "terraform_data" "script_model_config" {
-  depends_on = [
-    terraform_data.script_init
-  ]
-
   triggers_replace = {
     script_content = module.openclaw_scripts.model_config_script
     ssh_host       = local.ssh_endpoint[0]
     ssh_port       = local.ssh_endpoint[1]
-    ssh_password   = var.root_password
+    private_key    = module.openclaw_scripts.openclaw_private_key
   }
 
   connection {
-    type     = "ssh"
-    host     = local.ssh_endpoint[0]
-    user     = "openclaw"
-    port     = local.ssh_endpoint[1]
-    password = var.root_password
+    type        = "ssh"
+    host        = self.triggers_replace.ssh_host
+    user        = "openclaw"
+    port        = self.triggers_replace.ssh_port
+    private_key = self.triggers_replace.private_key
   }
 
   provisioner "remote-exec" {
     inline = [
-      nonsensitive(module.openclaw_scripts.model_config_script),
+      nonsensitive(self.triggers_replace.script_content),
     ]
   }
 }
@@ -68,20 +40,20 @@ resource "terraform_data" "script_gateway_config" {
     version        = 1
     ssh_host       = local.ssh_endpoint[0]
     ssh_port       = local.ssh_endpoint[1]
-    ssh_password   = var.root_password
+    private_key    = module.openclaw_scripts.openclaw_private_key
   }
 
   connection {
-    type     = "ssh"
-    host     = local.ssh_endpoint[0]
-    user     = "openclaw"
-    port     = local.ssh_endpoint[1]
-    password = var.root_password
+    type        = "ssh"
+    host        = self.triggers_replace.ssh_host
+    user        = "openclaw"
+    port        = self.triggers_replace.ssh_port
+    private_key = self.triggers_replace.private_key
   }
 
   provisioner "remote-exec" {
     inline = [
-      nonsensitive(module.openclaw_scripts.gateway_config_script),
+      nonsensitive(self.triggers_replace.script_content),
     ]
   }
 }
@@ -98,17 +70,17 @@ resource "terraform_data" "script_channel_qq_config" {
   triggers_replace = {
     channel_qq_apply_script   = module.openclaw_scripts.channel_qq_apply_script
     channel_qq_destroy_script = module.openclaw_scripts.channel_qq_destroy_script
-    ssh_host       = local.ssh_endpoint[0]
-    ssh_port       = local.ssh_endpoint[1]
-    ssh_password   = var.root_password
+    ssh_host                  = local.ssh_endpoint[0]
+    ssh_port                  = local.ssh_endpoint[1]
+    private_key               = module.openclaw_scripts.openclaw_private_key
   }
 
   connection {
-    type     = "ssh"
-    host     = self.triggers_replace.ssh_host
-    user     = "openclaw"
-    port     = self.triggers_replace.ssh_port
-    password = self.triggers_replace.ssh_password
+    type        = "ssh"
+    host        = self.triggers_replace.ssh_host
+    user        = "openclaw"
+    port        = self.triggers_replace.ssh_port
+    private_key = self.triggers_replace.private_key
   }
 
   provisioner "remote-exec" {

--- a/openclaw/versions.tf
+++ b/openclaw/versions.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.0"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
   }
 }
 


### PR DESCRIPTION
## 改动内容

将 OpenClaw 实例初始化方式从 `remote-exec` + 密码登录改为 `user_data` 注入，并使用 `tls_private_key` 生成 ED25519 密钥对实现后续 SSH 免密登录。

### 主要变更

- **`openclaw_scripts/init.tf`**：新增 `tls_private_key` 资源生成 ED25519 密钥对；`init_script` 模板新增 `openclaw_public_key` 变量；新增 `openclaw_private_key` sensitive output 供后续配置脚本使用。
- **`templates/init.sh.tmpl`**：新增第 3 步，幂等地将公钥写入 `openclaw` 用户的 `~/.ssh/authorized_keys`（通过 `getent` 获取家目录，正确设置目录/文件权限与属主）。
- **`main.tf`**：`qiniu_compute_instance.openclaw` 通过 `user_data` 注入初始化脚本。
- **`scripts.tf`**：移除依赖密码登录的 `script_init`；`script_model_config` / `script_gateway_config` / `script_channel_qq_config` 的 SSH 连接改用私钥免密登录，并统一从 `self.triggers_replace` 取连接参数。
- **`versions.tf`**：新增 `hashicorp/tls` provider 依赖。

### 幂等性

初始化脚本所有步骤均幂等：用户存在则跳过创建、公钥已存在则跳过写入、linger 已开启则跳过、完成标志文件存在则直接退出。

## 说明

`tls_private_key` 生成的私钥会明文写入 terraform state（即便 output 标记为 sensitive）。如需将私钥隔离在 state 之外，后续可考虑改用云平台密钥对服务。