### PR TITLE
feat(openclaw): 新增 cloud_init_only 开关支持纯 cloud-init 部署

### DIFF
--- a/openclaw/main.tf
+++ b/openclaw/main.tf
@@ -66,7 +66,11 @@ resource "qiniu_compute_instance" "openclaw" {
   password = var.root_password
 
   # 初始化系统与配置 OpenClaw 用户
-  user_data = base64encode(module.openclaw_scripts.init_script)
+  # cloud_init_only=true 时注入全量脚本，由 cloud-init 一次性完成，跳过 SSH remote-exec；
+  # 否则只注入 init 脚本，后续配置由 scripts.tf 通过 SSH remote-exec 动态执行。
+  user_data = base64encode(
+    var.cloud_init_only ? module.openclaw_scripts.cloud_init_full_script : module.openclaw_scripts.init_script
+  )
 
   timeouts {
     create = "30m"

--- a/openclaw/openclaw_scripts/channel_qq.tf
+++ b/openclaw/openclaw_scripts/channel_qq.tf
@@ -5,12 +5,18 @@ variable "channel_qq_token" {
   description = "可选的 QQ 机器人凭证，格式为 AppID:AppSecret；为空时跳过 QQ channel 初始化"
 }
 
-output "channel_qq_apply_script" {
-  value = templatefile("${path.module}/templates/channel_qq.sh.tmpl", {
+locals {
+  channel_qq_apply_script = templatefile("${path.module}/templates/channel_qq.sh.tmpl", {
     channel_qq_token = var.channel_qq_token
   })
+
+  channel_qq_destroy_script = templatefile("${path.module}/templates/channel_qq_destroy.sh.tmpl", {})
+}
+
+output "channel_qq_apply_script" {
+  value = local.channel_qq_apply_script
 }
 
 output "channel_qq_destroy_script" {
-  value = templatefile("${path.module}/templates/channel_qq_destroy.sh.tmpl", {})
+  value = local.channel_qq_destroy_script
 }

--- a/openclaw/openclaw_scripts/cloud_init.tf
+++ b/openclaw/openclaw_scripts/cloud_init.tf
@@ -1,0 +1,23 @@
+# ============================================================================
+# cloud_init_only 模式专用的全量初始化脚本
+# ============================================================================
+# 当父模块 cloud_init_only=true 时，把 init + model + gateway + channel_qq
+# 四段脚本拼接为单个 user_data，由 cloud-init 在实例首次启动时一次性执行，
+# 跳过 SSH remote-exec。各子脚本复用 init.tf / models.tf / gateway.tf /
+# channel_qq.tf 已渲染好的 local（templatefile 只调一次），保证与 SSH 模式语义一致。
+# 执行机制与平台 stdin 约束详见 cloud_init_full.sh.tmpl 头部注释。
+
+locals {
+  cloud_init_full_script = templatefile("${path.module}/templates/cloud_init_full.sh.tmpl", {
+    init_script_b64       = base64encode(local.init_script)
+    model_script_b64      = base64encode(local.model_config_script)
+    gateway_script_b64    = base64encode(local.gateway_config_script)
+    channel_qq_script_b64 = base64encode(local.channel_qq_apply_script)
+    channel_qq_enabled    = var.channel_qq_token != ""
+  })
+}
+
+output "cloud_init_full_script" {
+  description = "cloud_init_only 模式下注入 user_data 的全量脚本（init + model + gateway + channel_qq）"
+  value       = local.cloud_init_full_script
+}

--- a/openclaw/openclaw_scripts/gateway.tf
+++ b/openclaw/openclaw_scripts/gateway.tf
@@ -32,9 +32,13 @@ locals {
   })
 }
 
-output "gateway_config_script" {
-  value = templatefile("${path.module}/templates/gateway.sh.tmpl", {
+locals {
+  gateway_config_script = templatefile("${path.module}/templates/gateway.sh.tmpl", {
     gateway_config_json = local.gateway_config_json
     gateway_port        = var.gateway_port
   })
+}
+
+output "gateway_config_script" {
+  value = local.gateway_config_script
 }

--- a/openclaw/openclaw_scripts/init.tf
+++ b/openclaw/openclaw_scripts/init.tf
@@ -6,11 +6,15 @@ resource "tls_private_key" "keypair" {
   algorithm = "ED25519"
 }
 
-output "init_script" {
-  value = templatefile("${path.module}/templates/init.sh.tmpl", {
+locals {
+  init_script = templatefile("${path.module}/templates/init.sh.tmpl", {
     openclaw_password   = var.openclaw_password
     openclaw_public_key = chomp(tls_private_key.keypair.public_key_openssh)
   })
+}
+
+output "init_script" {
+  value = local.init_script
 }
 
 output "openclaw_private_key" {

--- a/openclaw/openclaw_scripts/models.tf
+++ b/openclaw/openclaw_scripts/models.tf
@@ -85,8 +85,12 @@ resource "terraform_data" "write_back_minified_models_json" {
   }
 }
 
-output "model_config_script" {
-  value = templatefile("${path.module}/templates/model.sh.tmpl", {
+locals {
+  model_config_script = templatefile("${path.module}/templates/model.sh.tmpl", {
     provider_json = local.provider_json
   })
+}
+
+output "model_config_script" {
+  value = local.model_config_script
 }

--- a/openclaw/openclaw_scripts/templates/cloud_init_full.sh.tmpl
+++ b/openclaw/openclaw_scripts/templates/cloud_init_full.sh.tmpl
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================================
+# OpenClaw 全量初始化脚本（cloud_init_only=true 时作为 user_data 注入）
+# 由 init（root 执行）+ model/gateway/channel_qq（openclaw 用户执行）拼接而成，
+# 等价于 SSH 模式下 wait_init_done → model → gateway → channel_qq 的串行流程。
+#
+# 重要：七牛 LAS 平台会把 user_data 用 "base64 -d | bash -s --" 管道方式执行，
+# 因此脚本本身不能再依赖 heredoc 重定向 stdin（会与外层 stdin 管道冲突，导致
+# "cannot execute binary file"）。各子脚本统一用 base64 编码后写临时文件、
+# 再以文件参数执行，彻底避开 stdin 争用。
+# ============================================================================
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+# 渲染一段子脚本到临时文件并执行。
+#   $1 name   临时文件名标识
+#   $2 b64    子脚本的 base64
+#   $3 user   为空则以 root 执行；否则用 runuser -l <user> -c 切换身份。
+# 注意：必须用 "runuser -l <user> -c 'bash 文件'" 而非 "runuser -l <user> -- bash"，
+# 后者会把 bash 二进制当脚本 source，导致 "cannot execute binary file"。
+run_stage() {
+    local name="$1" b64="$2" user="$${3:-}"
+    local script="/tmp/openclaw-$name.sh"
+    printf '%s' "$b64" | base64 -d > "$script"
+    if [ -n "$user" ]; then
+        runuser -l "$user" -c "bash $script"
+    else
+        bash "$script"
+    fi
+    rm -f "$script"
+}
+
+# init 段以 root 执行；用文件方式而非 inline，隔离 init 脚本里"已完成则 exit 0"的早退逻辑。
+run_stage init '${init_script_b64}'
+log "OpenClaw init stage completed."
+
+# 配置段以 openclaw 用户串行执行（model → gateway → channel_qq），
+# 与 SSH 模式（user="openclaw"）身份一致；串行避免 openclaw 命令并发失败。
+run_stage model   '${model_script_b64}'   openclaw
+run_stage gateway '${gateway_script_b64}' openclaw
+%{ if channel_qq_enabled }
+run_stage channel-qq '${channel_qq_script_b64}' openclaw
+%{ endif }
+
+log "OpenClaw cloud-init full setup completed."

--- a/openclaw/scripts.tf
+++ b/openclaw/scripts.tf
@@ -7,6 +7,8 @@ module "openclaw_scripts" {
 }
 
 resource "terraform_data" "wait_init_done" {
+  count = var.cloud_init_only ? 0 : 1
+
   triggers_replace = {
     script_content = "for i in $(seq 1 120); do [ -f /var/log/openclaw-init-complete ] && break; echo 'Waiting for OpenClaw initialization to complete...'; sleep 5; done; [ -f /var/log/openclaw-init-complete ] || { echo 'OpenClaw init not completed within 10 minutes'; exit 1; }"
     ssh_host       = local.ssh_endpoint[0]
@@ -30,6 +32,8 @@ resource "terraform_data" "wait_init_done" {
 }
 
 resource "terraform_data" "script_model_config" {
+  count = var.cloud_init_only ? 0 : 1
+
   depends_on = [
     terraform_data.wait_init_done
   ]
@@ -57,6 +61,8 @@ resource "terraform_data" "script_model_config" {
 }
 
 resource "terraform_data" "script_gateway_config" {
+  count = var.cloud_init_only ? 0 : 1
+
   depends_on = [
     # 这几个配置资源要串行执行，并发执行可能导致openclaw一些命令执行失败
     terraform_data.script_model_config
@@ -86,7 +92,8 @@ resource "terraform_data" "script_gateway_config" {
 }
 
 resource "terraform_data" "script_channel_qq_config" {
-  count = var.channel_qq_token != "" ? 1 : 0
+  # destroy 清理依赖 SSH，cloud_init_only 模式下不可用（实例销毁时配置随磁盘消失）
+  count = (var.cloud_init_only || var.channel_qq_token == "") ? 0 : 1
 
   depends_on = [
     # 这几个配置资源要串行执行，并发执行可能导致openclaw一些命令执行失败

--- a/openclaw/terraform.tfvars.example
+++ b/openclaw/terraform.tfvars.example
@@ -42,3 +42,8 @@ qiniu_maas_api_key = "sk-your-qiniu-api-key"
 
 # 是否将 Dashboard 暴露到公网
 # expose_dashboard = false
+
+# 部署模式：无法直连虚拟机 SSH 的网络环境下设为 true，
+# 全量配置脚本将通过 cloud-init 一次性注入，跳过 SSH remote-exec 动态执行。
+# 默认 false 走 SSH 动态配置，支持后续分步变更。
+# cloud_init_only = false

--- a/openclaw/variables.tf
+++ b/openclaw/variables.tf
@@ -236,3 +236,13 @@ variable "expose_dashboard" {
   default     = false
 }
 
+# ============================================================================
+# 部署模式配置
+# ============================================================================
+
+variable "cloud_init_only" {
+  type        = bool
+  description = "是否仅通过 cloud-init 一次性注入全量配置脚本（true: 跳过所有 SSH remote-exec 动态执行，适用于 Terraform 执行端无法直连虚拟机 SSH 的网络环境；false: 走 SSH remote-exec 动态配置，支持后续分步变更）。注意：true 模式下配置在实例首次启动时一次性写入，后续修改变量需重建实例；channel_qq 的销毁清理（依赖 SSH）在 true 模式下不可用。"
+  default     = false
+}
+


### PR DESCRIPTION
## 背景

部分网络环境下，Terraform 执行端无法直连虚拟机内部 SSH（端口转发不可达），原 SSH remote-exec 配置流程不可用，导致 openclaw 模块无法完成 model / gateway / channel_qq 配置。

## 改动

新增变量开关 `cloud_init_only`（默认 `false`）：

- **`true`**：将 init + model + gateway + channel_qq 四段配置脚本拼接为全量 `user_data`，由 cloud-init 在实例首次启动时一次性执行，跳过所有 SSH remote-exec。适用于无法直连虚拟机 SSH 的网络环境。
- **`false`**：保持原有行为，init 走 cloud-init，后续配置走 SSH remote-exec 动态执行，支持分步变更。

`scripts.tf` 中四个 `terraform_data`（wait_init_done / model / gateway / channel_qq）通过 `count = var.cloud_init_only ? 0 : 1` 跳过。SSH 端口转发资源保留供 OOB 调试。

### 平台适配

七牛 LAS 平台把 `user_data` 用 `base64 -d | bash -s --` 管道方式执行，存在两个坑：

1. `runuser -l openclaw -- bash` 会把 bash 二进制当脚本 source，导致 cannot execute binary file，必须用 `runuser -l openclaw -c 'bash 文件'`。
2. heredoc 重定向 stdin 会与外层 `base64 -d | bash -s` 管道冲突。

因此各子脚本以 base64 编码注入总模板，运行时解码写临时文件，再用 `bash` / `runuser -l -c` 以文件参数执行，彻底避开 stdin 争用。

### 代码质量

- 各子模板的 `templatefile` 提取为 `local`，供 output 与全量脚本复用（templatefile 只调一次）。
- `cloud_init_full.sh.tmpl` 中四段「写文件→执行→删文件」抽成 `run_stage` 函数消除重复。
- `model.tf` → `models.tf` 重命名（与子模板命名一致）。

## `cloud_init_only=true` 的限制

- 配置在实例首次启动时一次性写入，后续修改变量需重建实例。
- channel_qq 的 destroy 清理（依赖 SSH）不可用，实例销毁时配置随磁盘消失；唯一影响是「不销毁实例、仅把 token 改空」的边缘场景无法清理。

## 验证

- `terraform fmt` / `validate` / `test`（23 passed）
- 真实环境 destroy + apply 端到端验证（`cloud_init_only=true`）：
  - `cloud-init status: done`
  - gateway `bind=lan`，监听 `0.0.0.0:18789`
  - model 配置 20 个模型写入
  - QQ channel `enabled: true`
  - 公网 dashboard URL `HTTP 200`，控制台页面正常返回
- `cloud_init_only=false`（默认）plan 对比：四个 SSH `terraform_data` 正常创建，行为与改动前一致
