### PR TITLE
feat(openclaw): 支持配置公网 IP 类型

### DIFF
--- a/openclaw/main.tf
+++ b/openclaw/main.tf
@@ -53,8 +53,8 @@ resource "qiniu_compute_instance" "openclaw" {
   internet_max_bandwidth = var.internet_max_bandwidth
   internet_charge_type   = var.internet_charge_type
 
-  internet_public_ip_type = "Shared" # OpenClaw 目前只支持标准网络实例
-  disable_public_ip       = true     # OpenClaw 目前只支持标准网络实例
+  internet_public_ip_type = var.internet_public_ip_type
+  disable_public_ip       = true # OpenClaw 目前只支持标准网络实例
 
   # 计费配置
   cost_charge_type          = var.cost_charge_type

--- a/openclaw/variables.tf
+++ b/openclaw/variables.tf
@@ -246,3 +246,12 @@ variable "cloud_init_only" {
   default     = false
 }
 
+variable "internet_public_ip_type" {
+  type    = string
+  default = null
+
+  validation {
+    condition     = var.internet_public_ip_type == null || contains(["Shared", "Dedicated"], var.internet_public_ip_type)
+    error_message = "internet_public_ip_type must be Shared or Dedicated."
+  }
+}


### PR DESCRIPTION
## Summary
- 将 OpenClaw 实例的 `internet_public_ip_type` 从固定 `Shared` 改为可配置变量
- 新增 `internet_public_ip_type` 变量，允许 `Shared` / `Dedicated` / `null`

## Test Plan
- [x] `terraform fmt -check -diff`
- [x] `terraform validate`