### PR TITLE
feat(ci-runner): support GitHub App private key Data URI

### DIFF
--- a/apps/ci-runner/single/README.md
+++ b/apps/ci-runner/single/README.md
@@ -81,6 +81,8 @@ enable_ssh_port_forward = false
 ```bash
 export TF_VAR_github_oauth_client_secret="<github-oauth-client-secret>"
 export TF_VAR_github_app_private_key="$(cat /path/to/github-app.pem)"
+# 或使用浏览器下载得到的 data:...;base64,... 内容（二选一）
+# export TF_VAR_github_app_private_key_data_uri="data:application/octet-stream;name=github-app.pem;base64,..."
 ```
 
 本目录的 `.gitignore` 已忽略 `*.tfvars`、`env.sh` 和 Terraform state；仍需确认这些文件不会被复制、上传或提交到其他位置。
@@ -182,7 +184,8 @@ terraform destroy
 | `github_app_slug` | 是 | - | GitHub App slug |
 | `github_oauth_client_id` | 是 | - | GitHub App OAuth Client ID |
 | `github_oauth_client_secret` | 是 | - | GitHub App OAuth Client secret，敏感 |
-| `github_app_private_key` | 是 | - | GitHub App PEM 私钥原文，敏感 |
+| `github_app_private_key` | 二选一 | - | GitHub App PEM 私钥原文，敏感 |
+| `github_app_private_key_data_uri` | 二选一 | `null` | GitHub App 私钥 Data URI，敏感 |
 | `bootstrap_admin_github_login` | 是 | - | 初始管理员的 GitHub 用户名（自动解析为数字 ID） |
 | `instance_type` | 否 | `ecs.t1s.c1m2` | ECS 实例规格 |
 | `system_disk_size` | 否 | `20` | 系统盘大小，20–500 GiB，10 的倍数 |

--- a/apps/ci-runner/single/main.tf
+++ b/apps/ci-runner/single/main.tf
@@ -3,6 +3,21 @@ locals {
   runnerd_port = 25500
   # runnerd 版本，升级时修改此处
   runnerd_version = "v0.2.4"
+  github_app_private_key = trimspace(
+    var.github_app_private_key != null && trimspace(var.github_app_private_key) != ""
+    ? var.github_app_private_key
+    : try(base64decode(split(",", trimspace(var.github_app_private_key_data_uri))[1]), "")
+  )
+}
+
+check "github_app_private_key_input" {
+  assert {
+    condition = (
+      (length(trimspace(var.github_app_private_key == null ? "" : var.github_app_private_key)) > 0 ? 1 : 0) +
+      (length(trimspace(var.github_app_private_key_data_uri == null ? "" : var.github_app_private_key_data_uri)) > 0 ? 1 : 0) == 1
+    )
+    error_message = "github_app_private_key 和 github_app_private_key_data_uri 必须且只能设置一个。"
+  }
 }
 
 module "github_utils" {
@@ -44,7 +59,7 @@ module "runnerd" {
   runnerd_version                = local.runnerd_version
   runnerd_port                   = local.runnerd_port
   config_content                 = module.config.config_content
-  github_app_private_key         = var.github_app_private_key
+  github_app_private_key         = local.github_app_private_key
   bootstrap_admin_github_user_id = module.github_utils.user_id
 }
 

--- a/apps/ci-runner/single/variables.tf
+++ b/apps/ci-runner/single/variables.tf
@@ -59,6 +59,7 @@ variable "github_oauth_client_secret" {
 
 variable "github_app_private_key" {
   type        = string
+  default     = null
   description = <<-EOT
     GitHub App 的 PEM 私钥原文，敏感值。
     获取位置：GitHub App 设置页 https://github.com/settings/apps/<slug> 底部 "Private keys" 区域，
@@ -69,10 +70,35 @@ variable "github_app_private_key" {
 
   validation {
     condition = (
-      can(regex("-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY-----", trimspace(var.github_app_private_key))) &&
-      can(regex("-----END (RSA |EC |OPENSSH )?PRIVATE KEY-----", trimspace(var.github_app_private_key)))
+      length(trimspace(var.github_app_private_key == null ? "" : var.github_app_private_key)) == 0 || (
+        can(regex("-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY-----", trimspace(var.github_app_private_key == null ? "" : var.github_app_private_key))) &&
+        can(regex("-----END (RSA |EC |OPENSSH )?PRIVATE KEY-----", trimspace(var.github_app_private_key == null ? "" : var.github_app_private_key)))
+      )
     )
     error_message = "github_app_private_key 必须是有效的 PEM 私钥原文。"
+  }
+}
+
+variable "github_app_private_key_data_uri" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    GitHub App 私钥的 Data URI，敏感值；与 github_app_private_key 二选一。
+    可直接使用浏览器下载得到的 data:...;base64,... 格式内容。
+    建议通过环境变量 TF_VAR_github_app_private_key_data_uri 注入，不要提交到代码库。
+  EOT
+  sensitive   = true
+
+  validation {
+    condition = (
+      length(trimspace(var.github_app_private_key_data_uri == null ? "" : var.github_app_private_key_data_uri)) == 0 || (
+        startswith(trimspace(var.github_app_private_key_data_uri == null ? "" : var.github_app_private_key_data_uri), "data:") &&
+        length(split(",", trimspace(var.github_app_private_key_data_uri == null ? "" : var.github_app_private_key_data_uri))) == 2 &&
+        can(regex("-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY-----", base64decode(split(",", trimspace(var.github_app_private_key_data_uri == null ? "" : var.github_app_private_key_data_uri))[1]))) &&
+        can(regex("-----END (RSA |EC |OPENSSH )?PRIVATE KEY-----", base64decode(split(",", trimspace(var.github_app_private_key_data_uri == null ? "" : var.github_app_private_key_data_uri))[1])))
+      )
+    )
+    error_message = "github_app_private_key_data_uri 必须是包含有效 PEM 私钥的 Base64 Data URI。"
   }
 }
 

--- a/apps/ci-runner/single/variables.tftest.hcl
+++ b/apps/ci-runner/single/variables.tftest.hcl
@@ -43,6 +43,36 @@ run "rejects_base64_encoded_github_app_private_key" {
   expect_failures = [var.github_app_private_key]
 }
 
+run "accepts_github_app_private_key_data_uri" {
+  command = plan
+
+  variables {
+    github_app_private_key          = null
+    github_app_private_key_data_uri = "data:application/octet-stream;name=test.pem;base64,LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCnRlc3Qta2V5Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K"
+  }
+}
+
+run "rejects_both_github_app_private_key_inputs" {
+  command = plan
+
+  variables {
+    github_app_private_key_data_uri = "data:application/octet-stream;base64,LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCnRlc3Qta2V5Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K"
+  }
+
+  expect_failures = [check.github_app_private_key_input]
+}
+
+run "rejects_missing_github_app_private_key_input" {
+  command = plan
+
+  variables {
+    github_app_private_key          = null
+    github_app_private_key_data_uri = null
+  }
+
+  expect_failures = [check.github_app_private_key_input]
+}
+
 run "rejects_invalid_instance_type_format" {
   command = plan
 


### PR DESCRIPTION
## 背景

PR #54 已合并。本 PR 补充 GitHub App 私钥的 Data URI 输入方式，兼容浏览器下载得到的 `data:...;base64,...` 内容。

## 变更

- 新增 `github_app_private_key_data_uri` 输入变量。
- `github_app_private_key` 与 `github_app_private_key_data_uri` 必须二选一。
- Terraform 侧解析 Data URI、Base64 解码并统一清理首尾空白，内部仍传递标准 PEM 内容。
- 更新 README 和变量测试，覆盖 Data URI、两者同时设置和两者都未设置的场景。

## 验证

- `terraform test`：12 passed
- `terraform validate`：通过
- `terraform fmt -check`：通过
